### PR TITLE
Add F# + Giraffe + Tailwind server side rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ It's not unusual that excel file has 20 000 lines of data. Rendering the data wi
 3. Next.js with CSR
 4. GO & HTMX - TODO: and/or just GO?
 5. Excel - TODO: is it worth it?
+6. F# with Giraffe

--- a/fsharp-giraffe/.config/dotnet-tools.json
+++ b/fsharp-giraffe/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas": {
+      "version": "6.3.10",
+      "commands": [
+        "fantomas"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/fsharp-giraffe/.gitignore
+++ b/fsharp-giraffe/.gitignore
@@ -1,0 +1,3 @@
+bin
+obj
+wwwroot

--- a/fsharp-giraffe/Program.fs
+++ b/fsharp-giraffe/Program.fs
@@ -1,0 +1,44 @@
+﻿open Microsoft.AspNetCore.Builder
+open Giraffe
+open Giraffe.ViewEngine
+
+type Player = { name: string; score: uint }
+type Players = { players: Player[] }
+
+let players =
+    "../players.json"
+    |> System.IO.File.OpenRead
+    |> System.Text.Json.JsonSerializer.Deserialize<Players>
+    |> _.players
+    |> Array.toList
+
+let index content =
+    html
+        [ _lang "en" ]
+        [ head
+              []
+              [ meta [ _charset "UTF-8" ]
+                meta [ _httpEquiv "X-UA-Compatible"; _content "IE=edge" ]
+                meta [ _name "viewport"; _content "width=device-width, initial-scale=1.0" ]
+                link [ _rel "stylesheet"; _href "/styles.css" ]
+                title [] [ encodedText "F# Template Rendering" ] ]
+          body [ _class "container" ] content ]
+
+let playerDiv player =
+    li [ _class "my-2 ml-2 bg-white odd:bg-gray-50" ] [ encodedText $"{player.name} - {player.score}" ]
+
+let playerList players =
+    [ div
+          [ _class "ml-2" ]
+          [ h1 [ _class "text-xl my-4" ] [ encodedText "Players" ]
+            ul [ _class "border" ] (players |> List.map playerDiv) ] ]
+
+let routes = choose [ route "/" >=> htmlView (players |> playerList |> index) ]
+
+let builder = WebApplication.CreateBuilder()
+builder.Services.AddGiraffe() |> ignore
+
+let app = builder.Build()
+app.UseGiraffe(routes)
+app.UseStaticFiles() |> ignore
+app.Run "http://localhost:8000"

--- a/fsharp-giraffe/README.md
+++ b/fsharp-giraffe/README.md
@@ -1,0 +1,9 @@
+# F# & Giraffe
+
+## Running the application
+
+- Build tailwind styles `npx tailwindcss -i ./tailwind.css -o ./wwwroot/styles.css`
+- Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download)
+- Install dependencies `dotnet restore`
+- Start the server `dotnet run`
+- Server available at [http://localhost:8000](http://localhost:8000)

--- a/fsharp-giraffe/README.md
+++ b/fsharp-giraffe/README.md
@@ -5,5 +5,5 @@
 - Build tailwind styles `npx tailwindcss -i ./tailwind.css -o ./wwwroot/styles.css`
 - Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download)
 - Install dependencies `dotnet restore`
-- Start the server `dotnet run`
+- Start the server `dotnet run --configuration release`
 - Server available at [http://localhost:8000](http://localhost:8000)

--- a/fsharp-giraffe/fsharp-giraffe.fsproj
+++ b/fsharp-giraffe/fsharp-giraffe.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>fsharp_giraffe</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="giraffe" Version="7.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/fsharp-giraffe/tailwind.config.js
+++ b/fsharp-giraffe/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./**/*.fs"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+

--- a/fsharp-giraffe/tailwind.css
+++ b/fsharp-giraffe/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
Replicates rendered Html structure of the go app (kind of).

The setup does not currently detect changes in tailwind classes automatically and requires building the tailwind classes for the changes to take an effect in the rendered output.

Link to [Giraffe](https://github.com/giraffe-fsharp/Giraffe).

The setup uses dotnet tool [Fantomas](https://github.com/fsprojects/fantomas) for code formatting. To use the tool run `dotnet tool restore`

![image](https://github.com/user-attachments/assets/90dffc4c-393d-4e2a-a042-9071b6c98133)
